### PR TITLE
Update spde.R

### DIFF
--- a/R/spde.R
+++ b/R/spde.R
@@ -179,7 +179,7 @@ materncov.bands <- function(manifold, dist, log.range,
 #' @author Finn Lindgren \email{Finn.Lindgren@@ed.ac.uk}
 
 spde.posterior <- function(result, name, what = "range") {
-  spdespec <- result$sppa$model$effects[[name]]$model
+  spdespec <- result$sppa$model$effects[[name]]$main$model
   spderesult <- INLA::inla.spde.result(result, name, spdespec)
 
   if (what == "matern.correlation" || what == "matern.covariance") {


### PR DESCRIPTION
When using the example code in the readme I end up getting an error when trying to run `spde.posterior(fit, 'mySmooth', what = 'range')`. 

```
Error in UseMethod("inla.spde.result", list(...)[[3]]) : 
  no applicable method for 'inla.spde.result' applied to an object of class "NULL"
```
I believe this change is all that's needed for the function to work. 

This was performed using:
```
> sessionInfo()
R version 4.0.2 (2020-06-22)
Platform: x86_64-w64-mingw32/x64 (64-bit)
Running under: Windows 10 x64 (build 19041)

Matrix products: default

locale:
[1] LC_COLLATE=English_United States.1252  LC_CTYPE=English_United States.1252    LC_MONETARY=English_United States.1252
[4] LC_NUMERIC=C                           LC_TIME=English_United States.1252    

attached base packages:
[1] parallel  stats     graphics  grDevices utils     datasets  methods   base     

other attached packages:
[1] INLA_20.10.12-1    foreach_1.5.0      Matrix_1.2-18      inlabru_2.1.14.900 sp_1.4-4           ggplot2_3.3.2     

loaded via a namespace (and not attached):
 [1] pillar_1.4.6          compiler_4.0.2        iterators_1.0.12      tools_4.0.2           rpart_4.1-15          goftest_1.2-2        
 [7] lifecycle_0.2.0       tibble_3.0.4          gtable_0.3.0          nlme_3.1-148          lattice_0.20-41       mgcv_1.8-31          
[13] pkgconfig_2.0.3       rlang_0.4.8           rstudioapi_0.11       rgdal_1.5-18          spatstat.data_1.4-3   withr_2.3.0          
[19] dplyr_1.0.2           MatrixModels_0.4-1    generics_0.0.2        vctrs_0.3.4           spatstat.utils_1.17-0 grid_4.0.2           
[25] tidyselect_1.1.0      glue_1.4.2            R6_2.5.0              polyclip_1.10-0       purrr_0.3.4           deldir_0.1-25        
[31] magrittr_1.5          tensor_1.5            codetools_0.2-16      scales_1.1.1          ellipsis_0.3.1        MASS_7.3-51.6        
[37] splines_4.0.2         abind_1.4-5           spatstat_1.64-1       colorspace_1.4-1      Deriv_4.0.1           munsell_0.5.0        
[43] crayon_1.3.4 
```