### PR TITLE
fix "object val not found" bug and remove duplicate code

### DIFF
--- a/R/effect.R
+++ b/R/effect.R
@@ -1335,9 +1335,9 @@ ibm_amatrix.default <- function(mapper, ...) {
 #' @rdname bru_mapper_methods
 ibm_amatrix.bru_mapper_inla_mesh_2d <- function(mapper, input, ...) {
   if (!is.matrix(input) && !inherits(input, "Spatial")) {
-    val <- as.matrix(val)
-  }
-  INLA::inla.spde.make.A(mapper[["mesh"]], loc = input)
+    val <- as.matrix(input)
+  } else { val <- input }
+  INLA::inla.spde.make.A(mapper[["mesh"]], loc = val)
 }
 
 
@@ -1365,15 +1365,6 @@ ibm_n.bru_mapper_inla_mesh_2d <- function(mapper, ...) {
 #' @rdname bru_mapper_methods
 ibm_values.bru_mapper_inla_mesh_2d <- function(mapper, ...) {
   seq_len(mapper[["mesh"]]$n)
-}
-#' @param input The values for which to produce a mapping matrix
-#' @export
-#' @rdname bru_mapper_methods
-ibm_amatrix.bru_mapper_inla_mesh_2d <- function(mapper, input, ...) {
-  if (!is.matrix(input) && !inherits(input, "Spatial")) {
-    val <- as.matrix(val)
-  }
-  INLA::inla.spde.make.A(mapper[["mesh"]], loc = input)
 }
 
 #' @param indexed logical; If `TRUE`, the `ibm_values()` output will be the


### PR DESCRIPTION
I ran into an error using `predict` and traced it back to `ibm_amatrix.bru_mapper_inla_mesh_2d`
I think this pull request fixes the bug. 

I was getting an error stating `object val not found` and when debugging it seems like this function expects an object `val` in its scope that was not there.  I was passing a `data.frame` to `predict` with a model that included a 2D mesh which is I believe how it ended up at this function and running 
```R
  if (!is.matrix(input) && !inherits(input, "Spatial")) {
    val <- as.matrix(val)
  }
```
Note however that I was not predicting from any model components that use the 2D mesh.  

I struggled to reproduce the error but eventually managed to do it after digging out some old code for the gorillas dataset I wrote with a distance sampling observation process.  I couldn't reproduce it in more simple situations.  It's a bit longer than a usual reprex so I've put it on pastebin https://pastebin.com/gBP8thqe

I spent a while VERY confused as to why my change wasn't being incorporated when I built the package.  Eventually I realised the function was duplicated lower in the script so my changes to this function were just being overwritten!  That is the deletion you will see below.  

This fix seemed to avoid the error on my machine and the predictions look sensible.  

```
> sessionInfo()
R version 4.0.3 (2020-10-10)
Platform: x86_64-pc-linux-gnu (64-bit)
Running under: Ubuntu 18.04.5 LTS

Matrix products: default
BLAS:   /usr/lib/x86_64-linux-gnu/blas/libblas.so.3.7.1
LAPACK: /usr/lib/x86_64-linux-gnu/lapack/liblapack.so.3.7.1

locale:
 [1] LC_CTYPE=en_GB.UTF-8       LC_NUMERIC=C               LC_TIME=en_GB.UTF-8       
 [4] LC_COLLATE=en_GB.UTF-8     LC_MONETARY=en_GB.UTF-8    LC_MESSAGES=en_GB.UTF-8   
 [7] LC_PAPER=en_GB.UTF-8       LC_NAME=C                  LC_ADDRESS=C              
[10] LC_TELEPHONE=C             LC_MEASUREMENT=en_GB.UTF-8 LC_IDENTIFICATION=C       

attached base packages:
[1] parallel  stats     graphics  grDevices utils     datasets  methods   base     

other attached packages:
[1] dplyr_1.0.2         sf_0.9-6            rgeos_0.5-5         INLA_20.10.12-1    
[5] foreach_1.5.1       Matrix_1.2-18       inlabru_2.1.15.9000 sp_1.4-4           
[9] ggplot2_3.3.2      

loaded via a namespace (and not attached):
 [1] Rcpp_1.0.5          pillar_1.4.7        compiler_4.0.3      class_7.3-17       
 [5] iterators_1.0.13    tools_4.0.3         digest_0.6.27       lifecycle_0.2.0    
 [9] tibble_3.0.4        gtable_0.3.0        lattice_0.20-41     pkgconfig_2.0.3    
[13] rlang_0.4.9         DBI_1.1.0           rstudioapi_0.13     rgdal_1.5-18       
[17] yaml_2.2.1          e1071_1.7-4         withr_2.3.0         MatrixModels_0.4-1 
[21] generics_0.1.0      vctrs_0.3.5         stats4_4.0.3        classInt_0.4-3     
[25] grid_4.0.3          tidyselect_1.1.0    glue_1.4.2          R6_2.5.0           
[29] sn_1.6-2            farver_2.0.3        purrr_0.3.4         magrittr_2.0.1     
[33] units_0.6-7         scales_1.1.1        codetools_0.2-16    ellipsis_0.3.1     
[37] splines_4.0.3       mnormt_2.0.2        colorspace_2.0-0    numDeriv_2016.8-1.1
[41] labeling_0.4.2      KernSmooth_2.23-18  munsell_0.5.0       tmvnsim_1.0-2      
[45] crayon_1.3.4    
```