### PR TITLE
implements new `probs` and `return.samples` options to `predict.bru`

### DIFF
--- a/R/bru.inference.R
+++ b/R/bru.inference.R
@@ -1047,7 +1047,7 @@ expand_to_dataframe <- function(x, data = NULL) {
 #' calculate the posterior statistics. The default is rather low but provides
 #' a quick approximate result.
 #' @param seed Random number generator seed passed on to `inla.posterior.sample`
-#' @param probs A numeric vector of probabilities with values in [0,1], passed to \code{stats::quantile}
+#' @param probs A numeric vector of probabilities with values in `[0, 1]`, passed to `stats::quantile`
 #' @param num.threads Specification of desired number of threads for parallel
 #' computations. Default NULL, leaves it up to INLA.
 #' When seed != 0, overridden to "1:1"
@@ -1412,7 +1412,7 @@ montecarlo.posterior <- function(dfun, sfun, x = NULL, samples = NULL,
 #
 # @export
 # @param data A list of samples, each either numeric or a \code{data.frame}
-# @param probs A numeric vector of probabilities with values in [0,1], passed to \code{stats::quantile}
+# @param probs A numeric vector of probabilities with values in `[0, 1]`, passed to `stats::quantile`
 # @param x A \code{data.frame} of data columns that should be added to the summary data frame
 # @param cbind.only If TRUE, only \code{cbind} the samples and return a matrix where each column is a sample
 # @return A \code{data.frame} or Spatial[Points/Pixels]DataFrame with summary statistics

--- a/R/bru.inference.R
+++ b/R/bru.inference.R
@@ -1084,7 +1084,7 @@ predict.bru <- function(object,
                         formula = NULL,
                         n.samples = 100,
                         seed = 0L,
-                        probs = c(0.025, 0.5, 0.075),
+                        probs = c(0.025, 0.5, 0.975),
                         return.samples = FALSE,
                         num.threads = NULL,
                         include = NULL,
@@ -1421,7 +1421,7 @@ montecarlo.posterior <- function(dfun, sfun, x = NULL, samples = NULL,
 # @param cbind.only If TRUE, only \code{cbind} the samples and return a matrix where each column is a sample
 # @return A \code{data.frame} or Spatial[Points/Pixels]DataFrame with summary statistics
 
-bru_summarise <- function(data, probs = c(0.025, 0.5, 0.075), x = NULL, cbind.only = FALSE) {
+bru_summarise <- function(data, probs = c(0.025, 0.5, 0.975), x = NULL, cbind.only = FALSE) {
   if (is.list(data)) {
     data <- do.call(cbind, data)
   }

--- a/R/bru.inference.R
+++ b/R/bru.inference.R
@@ -1047,6 +1047,8 @@ expand_to_dataframe <- function(x, data = NULL) {
 #' calculate the posterior statistics. The default is rather low but provides
 #' a quick approximate result.
 #' @param seed Random number generator seed passed on to `inla.posterior.sample`
+#' @param probs A numeric vector of probabilities with values in [0,1], passed to \code{stats::quantile}
+#' @param return.samples If TRUE, returns a matrix where each column is a sample
 #' @param num.threads Specification of desired number of threads for parallel
 #' computations. Default NULL, leaves it up to INLA.
 #' When seed != 0, overridden to "1:1"
@@ -1082,6 +1084,8 @@ predict.bru <- function(object,
                         formula = NULL,
                         n.samples = 100,
                         seed = 0L,
+                        probs = c(0.025, 0.5, 0.075),
+                        return.samples = FALSE,
                         num.threads = NULL,
                         include = NULL,
                         exclude = NULL,
@@ -1125,7 +1129,9 @@ predict.bru <- function(object,
             vals,
             function(v) v[[nm]]
           ),
-          x = vals[[1]][, covar, drop = FALSE]
+          x = vals[[1]][, covar, drop = FALSE],
+          probs = probs,
+          cbind.only = return.samples
         )
     }
     is.annot <- vapply(names(smy), function(v) all(smy[[v]]$sd == 0), TRUE)
@@ -1158,10 +1164,12 @@ predict.bru <- function(object,
     for (nm in vals.names) {
       tmp <-
         bru_summarise(
-          lapply(
+          data = lapply(
             vals,
             function(v) v[[nm]]
-          )
+          ),
+          probs = probs,
+          cbind.only = return.samples
         )
       if (!drop &&
         (NROW(data) == NROW(tmp))) {
@@ -1171,7 +1179,7 @@ predict.bru <- function(object,
       }
     }
   } else {
-    tmp <- bru_summarise(vals)
+    tmp <- bru_summarise(data = vals, probs = probs, cbind.only = return.samples)
     if (!drop &&
       (NROW(data) == NROW(tmp))) {
       smy <- expand_to_dataframe(data, tmp)
@@ -1408,11 +1416,12 @@ montecarlo.posterior <- function(dfun, sfun, x = NULL, samples = NULL,
 #
 # @export
 # @param data A list of samples, each either numeric or a \code{data.frame}
+# @param probs A numeric vector of probabilities with values in [0,1], passed to \code{stats::quantile}
 # @param x A \code{data.frame} of data columns that should be added to the summary data frame
 # @param cbind.only If TRUE, only \code{cbind} the samples and return a matrix where each column is a sample
 # @return A \code{data.frame} or Spatial[Points/Pixels]DataFrame with summary statistics
 
-bru_summarise <- function(data, x = NULL, cbind.only = FALSE) {
+bru_summarise <- function(data, probs = c(0.025, 0.5, 0.075), x = NULL, cbind.only = FALSE) {
   if (is.list(data)) {
     data <- do.call(cbind, data)
   }
@@ -1423,11 +1432,15 @@ bru_summarise <- function(data, x = NULL, cbind.only = FALSE) {
     smy <- data.frame(
       apply(data, MARGIN = 1, mean, na.rm = TRUE),
       apply(data, MARGIN = 1, sd, na.rm = TRUE),
-      t(apply(data, MARGIN = 1, quantile, prob = c(0.025, 0.5, 0.975), na.rm = TRUE)),
+      t(apply(data, MARGIN = 1, quantile, probs = probs, na.rm = TRUE)),
       apply(data, MARGIN = 1, min, na.rm = TRUE),
       apply(data, MARGIN = 1, max, na.rm = TRUE)
     )
-    colnames(smy) <- c("mean", "sd", "q0.025", "median", "q0.975", "smin", "smax")
+    qs_names <- paste0("q", probs)
+    if (any(qs_names == "q0.5")) {
+      qs_names[qs_names == "q0.5"] <- "median"
+    }
+    colnames(smy) <- c("mean", "sd", qs_names, "smin", "smax")
     smy$cv <- smy$sd / smy$mean
     smy$var <- smy$sd^2
   }

--- a/R/bru.inference.R
+++ b/R/bru.inference.R
@@ -1048,7 +1048,6 @@ expand_to_dataframe <- function(x, data = NULL) {
 #' a quick approximate result.
 #' @param seed Random number generator seed passed on to `inla.posterior.sample`
 #' @param probs A numeric vector of probabilities with values in [0,1], passed to \code{stats::quantile}
-#' @param return.samples If TRUE, returns a matrix where each column is a sample
 #' @param num.threads Specification of desired number of threads for parallel
 #' computations. Default NULL, leaves it up to INLA.
 #' When seed != 0, overridden to "1:1"
@@ -1085,7 +1084,6 @@ predict.bru <- function(object,
                         n.samples = 100,
                         seed = 0L,
                         probs = c(0.025, 0.5, 0.975),
-                        return.samples = FALSE,
                         num.threads = NULL,
                         include = NULL,
                         exclude = NULL,
@@ -1130,8 +1128,7 @@ predict.bru <- function(object,
             function(v) v[[nm]]
           ),
           x = vals[[1]][, covar, drop = FALSE],
-          probs = probs,
-          cbind.only = return.samples
+          probs = probs
         )
     }
     is.annot <- vapply(names(smy), function(v) all(smy[[v]]$sd == 0), TRUE)
@@ -1168,8 +1165,7 @@ predict.bru <- function(object,
             vals,
             function(v) v[[nm]]
           ),
-          probs = probs,
-          cbind.only = return.samples
+          probs = probs
         )
       if (!drop &&
         (NROW(data) == NROW(tmp))) {
@@ -1179,7 +1175,7 @@ predict.bru <- function(object,
       }
     }
   } else {
-    tmp <- bru_summarise(data = vals, probs = probs, cbind.only = return.samples)
+    tmp <- bru_summarise(data = vals, probs = probs)
     if (!drop &&
       (NROW(data) == NROW(tmp))) {
       smy <- expand_to_dataframe(data, tmp)

--- a/man/predict.bru.Rd
+++ b/man/predict.bru.Rd
@@ -11,7 +11,6 @@
   n.samples = 100,
   seed = 0L,
   probs = c(0.025, 0.5, 0.975),
-  return.samples = FALSE,
   num.threads = NULL,
   include = NULL,
   exclude = NULL,
@@ -37,8 +36,6 @@ a quick approximate result.}
 \item{seed}{Random number generator seed passed on to \code{inla.posterior.sample}}
 
 \item{probs}{A numeric vector of probabilities with values in \link{0,1}, passed to \code{stats::quantile}}
-
-\item{return.samples}{If TRUE, returns a matrix where each column is a sample}
 
 \item{num.threads}{Specification of desired number of threads for parallel
 computations. Default NULL, leaves it up to INLA.

--- a/man/predict.bru.Rd
+++ b/man/predict.bru.Rd
@@ -10,6 +10,8 @@
   formula = NULL,
   n.samples = 100,
   seed = 0L,
+  probs = c(0.025, 0.5, 0.075),
+  return.samples = FALSE,
   num.threads = NULL,
   include = NULL,
   exclude = NULL,
@@ -33,6 +35,10 @@ calculate the posterior statistics. The default is rather low but provides
 a quick approximate result.}
 
 \item{seed}{Random number generator seed passed on to \code{inla.posterior.sample}}
+
+\item{probs}{A numeric vector of probabilities with values in \link{0,1}, passed to \code{stats::quantile}}
+
+\item{return.samples}{If TRUE, returns a matrix where each column is a sample}
 
 \item{num.threads}{Specification of desired number of threads for parallel
 computations. Default NULL, leaves it up to INLA.

--- a/man/predict.bru.Rd
+++ b/man/predict.bru.Rd
@@ -10,7 +10,7 @@
   formula = NULL,
   n.samples = 100,
   seed = 0L,
-  probs = c(0.025, 0.5, 0.075),
+  probs = c(0.025, 0.5, 0.975),
   return.samples = FALSE,
   num.threads = NULL,
   include = NULL,

--- a/man/predict.bru.Rd
+++ b/man/predict.bru.Rd
@@ -35,7 +35,7 @@ a quick approximate result.}
 
 \item{seed}{Random number generator seed passed on to \code{inla.posterior.sample}}
 
-\item{probs}{A numeric vector of probabilities with values in \link{0,1}, passed to \code{stats::quantile}}
+\item{probs}{A numeric vector of probabilities with values in \verb{[0, 1]}, passed to \code{stats::quantile}}
 
 \item{num.threads}{Specification of desired number of threads for parallel
 computations. Default NULL, leaves it up to INLA.


### PR DESCRIPTION
This PR implements two simple options for `predict.bru`:

- `probs` allows the user to pass custom probabilities (via `bru_summarise`). It defaults to `probs = c(0.025, 0.5, 0.975)`, which is the current behaviour.
- `return.samples` overrides the `probs` option, and return a matrix of samples. Effectively, it simply "wires in" the existing `cbind.only` option of `bru_summarise`.

# Examples:

```R
# Required for reproducible predict() and generate() output.
set.seed(1234L)

input.df <- data.frame(x = cos(1:10), zz = rep(c(1, 10), each = 5))
input.df <- within(input.df, y <- 5 + 2 * cos(1:10) +
  rnorm(10, mean = 0, sd = 1)[zz] +
  rnorm(10, mean = 0, sd = 0.1))

# Fit a model with fixed effect 'x' and intercept 'Intercept'
fit <- bru(y ~ x + z(zz, model = "iid", mapper = bru_mapper_index(10)), family = "gaussian", data = input.df)
```

## For the `probs` option:

```R
x1 <- predict(
  fit,
  data = NULL,
  formula = ~ x_latent + fit$summary.random$z$mean[1],
  n.samples = 50, 
  probs = seq(0, 1, by = 0.2), 
  seed = 12345L
)
```

Which gives:

```R
> x1
      mean        sd       q0    q0.2     q0.4     q0.6     q0.8       q1     smin     smax
1 2.000632 0.0831341 1.843082 1.93589 1.978886 2.007566 2.052245 2.220725 1.843082 2.220725
          cv         var
1 0.04155393 0.006911278
```

Note that for a probability of `0.5`, the column name is automatically changed to `median` (current behaviour):

```R
x1.2 <- predict(
  fit,
  data = NULL,
  formula = ~ x_latent + fit$summary.random$z$mean[1],
  n.samples = 50, 
  probs = c(0.05, 0.5, 0.90), 
  seed = 12345L
)
```

Which gives:

```R
> x1.2
      mean         sd    q0.05   median     q0.9     smin     smax         cv        var
1 1.998391 0.07135222 1.894265 1.996368 2.092928 1.843082 2.151538 0.03570485 0.00509114
```

The default behaviour is the same as the current behaviour:

```R
x1.3 <- predict(
  fit,
  data = NULL,
  formula = ~ x_latent + fit$summary.random$z$mean[1],
  n.samples = 50, 
  seed = 12345L
)
```

Which gives:

```R
> x1.3
      mean         sd   q0.025   median   q0.975     smin     smax         cv         var
1 1.998759 0.06906419 1.895441 1.988629 2.140935 1.873755 2.194334 0.03455353 0.004769863
```


## For the `return.samples` option:

```R
x2 <- predict(
  fit,
  data = NULL,
  formula = ~ x_latent + fit$summary.random$z$mean[1],
  n.samples = 50, 
  return.samples = TRUE, 
  seed = 12345L
)
```

Which gives:

```R
> x2
  sample.1 sample.2 sample.3 sample.4 sample.5 sample.6 sample.7 sample.8 sample.9 sample.10
1 2.044666 2.004647  1.88739 2.040335 1.956185 2.056624 2.022956 1.991965 2.098645  2.044206
  sample.11 sample.12 sample.13 sample.14 sample.15 sample.16 sample.17 sample.18 sample.19
1  1.953144  2.014561  1.990395  1.912923  2.088756  1.888543    2.0334  2.125807  1.941713
  sample.20 sample.21 sample.22 sample.23 sample.24 sample.25 sample.26 sample.27 sample.28
1  2.172584  1.999395  1.865559  1.958225  2.000996   1.91859  1.891961  2.120751  2.154372
  sample.29 sample.30 sample.31 sample.32 sample.33 sample.34 sample.35 sample.36 sample.37
1  1.988764  1.921919  2.286053  1.897926  1.962047  1.983044  1.868498  1.979393  2.076378
  sample.38 sample.39 sample.40 sample.41 sample.42 sample.43 sample.44 sample.45 sample.46
1  2.020633  1.873755  1.974662  1.924925  1.969282  1.969128  1.959379  2.013215  1.948823
  sample.47 sample.48 sample.49 sample.50
1  2.045175  2.064974  2.057049  1.920725
```
