### PR TITLE
chore(infra): Add paths-ignore to R-CMD-check workflow

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -10,7 +10,7 @@ on:
     paths-ignore:
       - "README.Rmd"
       - "misc/**"
-      - "*.md"
+      - "cran-comments.md"
       - ".github/**"
       - "*.json "
       - "*.yaml"
@@ -25,7 +25,7 @@ on:
     paths-ignore:
       - "README.Rmd"
       - "misc/**"
-      - "*.md"
+      - "cran-comments.md"
       - ".github/**"
       - "*.json "
       - "*.yaml"

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -10,7 +10,6 @@ on:
     paths-ignore:
       - "README.Rmd"
       - "misc/**"
-      - "inst/**"
       - "*.md"
       - ".github/**"
       - "*.json "
@@ -18,16 +17,14 @@ on:
       - "*.yml"
       - ".gitignore"
       - "*.toml"
-      - "*.Rpoj"
+      - "*.Rproj"
       - ".lintr"
-      - ".Rbuildignore"
   pull_request:
     branches:
       - devel
     paths-ignore:
       - "README.Rmd"
       - "misc/**"
-      - "inst/**"
       - "*.md"
       - ".github/**"
       - "*.json "
@@ -35,9 +32,8 @@ on:
       - "*.yml"
       - ".gitignore"
       - "*.toml"
-      - "*.Rpoj"
+      - "*.Rproj"
       - ".lintr"
-      - ".Rbuildignore"
   workflow_dispatch:
     inputs:
       debug_enabled:

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -7,9 +7,37 @@ on:
       - stable
       - release/*
       - feature/*
+    paths-ignore:
+      - "README.Rmd"
+      - "misc/**"
+      - "inst/**"
+      - "*.md"
+      - ".github/**"
+      - "*.json "
+      - "*.yaml"
+      - "*.yml"
+      - ".gitignore"
+      - "*.toml"
+      - "*.Rpoj"
+      - ".lintr"
+      - ".Rbuildignore"
   pull_request:
     branches:
       - devel
+    paths-ignore:
+      - "README.Rmd"
+      - "misc/**"
+      - "inst/**"
+      - "*.md"
+      - ".github/**"
+      - "*.json "
+      - "*.yaml"
+      - "*.yml"
+      - ".gitignore"
+      - "*.toml"
+      - "*.Rpoj"
+      - ".lintr"
+      - ".Rbuildignore"
   workflow_dispatch:
     inputs:
       debug_enabled:

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -7,33 +7,37 @@ on:
       - stable
       - release/*
       - feature/*
-    paths-ignore:
-      - "README.Rmd"
-      - "misc/**"
-      - "cran-comments.md"
-      - ".github/**"
-      - "*.json "
-      - "*.yaml"
-      - "*.yml"
-      - ".gitignore"
-      - "*.toml"
-      - "*.Rproj"
-      - ".lintr"
+    paths:
+      - "**"
+      - "!README.Rmd"
+      - "!misc/**"
+      - "!cran-comments.md"
+      - "!.github/**"
+      - ".github/workflows/R-CMD-check.yaml"
+      - "!*.json "
+      - "!*.yaml"
+      - "!*.yml"
+      - "!.gitignore"
+      - "!*.toml"
+      - "!*.Rproj"
+      - "!.lintr"
   pull_request:
     branches:
       - devel
-    paths-ignore:
-      - "README.Rmd"
-      - "misc/**"
-      - "cran-comments.md"
-      - ".github/**"
-      - "*.json "
-      - "*.yaml"
-      - "*.yml"
-      - ".gitignore"
-      - "*.toml"
-      - "*.Rproj"
-      - ".lintr"
+    paths:
+      - "**"
+      - "!README.Rmd"
+      - "!misc/**"
+      - "!cran-comments.md"
+      - "!.github/**"
+      - ".github/workflows/R-CMD-check.yaml"
+      - "!*.json "
+      - "!*.yaml"
+      - "!*.yml"
+      - "!.gitignore"
+      - "!*.toml"
+      - "!*.Rproj"
+      - "!.lintr"
   workflow_dispatch:
     inputs:
       debug_enabled:


### PR DESCRIPTION
Propose not to run the R-CMD check on files that are not part of the package build. I may have missed a file/dir. Maybe other workflows would benefit from this as well.